### PR TITLE
Log exceptions from emailing

### DIFF
--- a/Components/EmailTemplateController.vb
+++ b/Components/EmailTemplateController.vb
@@ -13,6 +13,7 @@ Imports Dotnetnuke.Entities.Portals
 Imports Dotnetnuke.Entities.Users
 Imports DotNetNuke.Framework
 Imports DotNetNuke.Security.Roles
+Imports DotNetNuke.Services.Exceptions
 
 Namespace Ventrian.NewsArticles
 
@@ -289,7 +290,8 @@ Namespace Ventrian.NewsArticles
             ' SendNotification(settings.Email, sendTo, Null.NullString, subject, template)
             Try
                 DotNetNuke.Services.Mail.Mail.SendMail(settings.Email, sendTo, "", subject, template, "", "", "", "", "", "")
-            Catch
+            Catch exc As Exception
+                LogException(exc)
             End Try
 
         End Sub


### PR DESCRIPTION
When SendMail throws an exception (e.g. settings.Email is blank), the
details of the exception should be logged.